### PR TITLE
Single blog page initializaiton

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import Contact from "./pages/Contact";
 import NotFound from "./pages/NotFound";
 import "./css/theme.css";
 import Blog from "./pages/Blog";
+import SingleBlogPage from "./pages/SingleBlogPage";
 
 function App() {
   return (
@@ -21,6 +22,8 @@ function App() {
           <Route path="projects" element={<Projects />} />
           <Route path="projects/:slug" element={<ProjectDetails />} />
           <Route path="blog" element={<Blog />} />
+          <Route path="/blogs/:id" element={<SingleBlogPage />} />
+
           <Route path="contact" element={<Contact />} />
           <Route path="*" element={<NotFound />} />
         </Route>

--- a/client/src/components/blogs/blogcard/BlogCard.jsx
+++ b/client/src/components/blogs/blogcard/BlogCard.jsx
@@ -1,8 +1,12 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 
 const BlogCard = ({ blog }) => {
   return (
+    <Link to={`/blogs/${blog.id}`} className="no-underline">
+      {/* Wrap the entire card in a Link to make it clickable */}
+
     <motion.div
       className="group relative bg-skin-card border border-skin-glow rounded-2xl overflow-hidden shadow-lg p-4 transition-transform duration-300 hover:-translate-y-2 hover:shadow-neon-glow"
       whileHover={{ scale: 1.03 }}
@@ -50,6 +54,7 @@ const BlogCard = ({ blog }) => {
         — {blog.author}
       </div>
     </motion.div>
+    </Link>
   );
 };
 

--- a/client/src/pages/SingleBlogPage.jsx
+++ b/client/src/pages/SingleBlogPage.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { useParams, Link } from "react-router-dom";
+import blogData from "../data/blogEntries.json";
+
+const SingleBlogPage = () => {
+  const { id } = useParams();
+  const blog = blogData.find((b) => b.id === parseInt(id));
+
+  if (!blog) {
+    return (
+      <div className="text-center mt-20 text-red-400">404 Blog Not Found</div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-skin-bg text-skin-accent px-6 py-16  mx-auto">
+      <Link to="/blog" className="text-sm text-skin-glow hover:underline">
+        &larr; Back to logs
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-4xl font-bold mb-4">
+          {blog.emoji} {blog.title}
+        </h1>
+
+        <div className="text-sm text-skin-muted mb-4">
+          {blog.date} — <span className="italic">by {blog.author}</span>
+        </div>
+
+        <img
+          src={blog.image}
+          alt={blog.title}
+          className="rounded-xl shadow-lg border border-skin-glow mb-6 w-full"
+        />
+
+        <p className="text-base leading-relaxed mb-6">{blog.description}</p>
+
+        <div className="flex flex-wrap gap-2 mt-6">
+          {blog.tags.map((tag, i) => (
+            <span
+              key={i}
+              className="px-3 py-0.5 text-xs font-mono border border-skin-glow rounded-full hover:bg-skin-glow hover:text-black transition"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SingleBlogPage;


### PR DESCRIPTION
This pull request introduces a new feature to display individual blog posts on a dedicated page. The changes include adding a new `SingleBlogPage` component, updating the routing in the application, and modifying the `BlogCard` component to link to the new page.

### New Feature: Single Blog Post Page

* **Addition of `SingleBlogPage` component**: Created a new component in `client/src/pages/SingleBlogPage.jsx` to display the details of a single blog post, including the title, author, date, image, description, and tags. The component uses `useParams` to fetch the blog post by its ID and displays a "404 Blog Not Found" message if the blog does not exist.

### Routing Updates

* **Updated routing in `App.jsx`**: Added a new route `/blogs/:id` to render the `SingleBlogPage` component when a specific blog post is accessed.
* **Imported `SingleBlogPage`**: Added the import statement for `SingleBlogPage` in `App.jsx`.

### BlogCard Enhancements

* **Added navigation to `BlogCard`**: Wrapped the `BlogCard` component with a `Link` element to make the entire card clickable, navigating to the corresponding blog post's page. [[1]](diffhunk://#diff-d214744d8aa4ff54a7100c2d25c9f256ae38a976a2afc14a099241742e2300d2R3-R9) [[2]](diffhunk://#diff-d214744d8aa4ff54a7100c2d25c9f256ae38a976a2afc14a099241742e2300d2R57)